### PR TITLE
Fix STM32 arch detection

### DIFF
--- a/Arduino/TTGO_Tiny_Basic/TTGO_Tiny_Basic_1/basic.h
+++ b/Arduino/TTGO_Tiny_Basic/TTGO_Tiny_Basic_1/basic.h
@@ -752,7 +752,7 @@ typedef mem_t (*memreader_t)(address_t);
 #define SYSTYPE_RP2040  4
 #define SYSTYPE_SAM     5
 #define SYSTYPE_XMC		6
-#define SYSTYPE_SMT32	7
+#define SYSTYPE_STM32	7
 #define SYSTYPE_NRENESA 8
 #define SYSTYPE_POSIX	32
 #define SYSTYPE_MSDOS	33

--- a/Arduino/TTGO_Tiny_Basic/TTGO_Tiny_Basic_1/hardware-arduino.h
+++ b/Arduino/TTGO_Tiny_Basic/TTGO_Tiny_Basic_1/hardware-arduino.h
@@ -535,8 +535,8 @@ const mem_t bsystype = SYSTYPE_RP2040;
 const mem_t bsystype = SYSTYPE_SAM;
 #elif defined(ARDUINO_ARCH_XMC)
 const mem_t bsystype = SYSTYPE_XMC;
-#elif defined(ARDUINO_ARCH_SMT32)
-const mem_t bsystype = SYSTYPE_SMT32;
+#elif defined(ARDUINO_ARCH_STM32)
+const mem_t bsystype = SYSTYPE_STM32;
 #elif defined(ARDUINO_ARCH_RENESAS)
 const mem_t bsystype = SYSTYPE_NRENESA;
 #else

--- a/Arduino/TTGO_Tiny_Basic/TTGO_Tiny_Basic_2/hardware.h
+++ b/Arduino/TTGO_Tiny_Basic/TTGO_Tiny_Basic_2/hardware.h
@@ -1201,7 +1201,7 @@
 #define FNLIMIT 64
 #elif defined(ARDUINO_ARCH_XMC)
 #define FNLIMIT 64
-#elif defined(ARDUINO_ARCH_SMT32)
+#elif defined(ARDUINO_ARCH_STM32)
 #define FNLIMIT 128
 #elif defined(ARDUINO_ARCH_RENESAS)
 #define FNLIMIT 32

--- a/Arduino/TTGO_Tiny_Basic/TTGO_Tiny_Basic_2/runtime.cpp
+++ b/Arduino/TTGO_Tiny_Basic/TTGO_Tiny_Basic_2/runtime.cpp
@@ -33,8 +33,8 @@ uint8_t bsystype = SYSTYPE_RP2040;
 uint8_t bsystype = SYSTYPE_SAM;
 #elif defined(ARDUINO_ARCH_XMC)
 uint8_t bsystype = SYSTYPE_XMC;
-#elif defined(ARDUINO_ARCH_SMT32)
-uint8_t bsystype = SYSTYPE_SMT32;
+#elif defined(ARDUINO_ARCH_STM32)
+uint8_t bsystype = SYSTYPE_STM32;
 #elif defined(ARDUINO_ARCH_RENESAS)
 uint8_t bsystype = SYSTYPE_NRENESA;
 #else

--- a/Arduino/TTGO_Tiny_Basic/TTGO_Tiny_Basic_2/runtime.h
+++ b/Arduino/TTGO_Tiny_Basic/TTGO_Tiny_Basic_2/runtime.h
@@ -30,7 +30,7 @@
 #define SYSTYPE_RP2040  4
 #define SYSTYPE_SAM     5
 #define SYSTYPE_XMC		6
-#define SYSTYPE_SMT32	7
+#define SYSTYPE_STM32	7
 #define SYSTYPE_NRENESA 8
 #define SYSTYPE_POSIX	32
 #define SYSTYPE_MSDOS	33


### PR DESCRIPTION
## Summary
- fix typo `ARDUINO_ARCH_SMT32`
- rename `SYSTYPE_SMT32` constant to `SYSTYPE_STM32`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840e2342df88324b3a5368dbb726a20