### PR TITLE
Fix typo in TTGO Tiny Basic intro comment

### DIFF
--- a/Arduino/TTGO_Tiny_Basic/TTGO_Tiny_Basic_1/TTGO_Tiny_Basic_1.ino
+++ b/Arduino/TTGO_Tiny_Basic/TTGO_Tiny_Basic_1/TTGO_Tiny_Basic_1.ino
@@ -10,7 +10,7 @@
  *
  *	Author: Stefan Lenz, sl001@serverfabrik.de
  *
- *	The first set of definions define the target.
+ *	The first set of definitions define the target.
  *	- MINGW switches on Windows calls - this is the mingw.org version 
  *  _ MINGW64 like MINGW but with the mingw 64 support 
  *	- MSDOS for MSDOS file access.


### PR DESCRIPTION
## Summary
- correct a misspelling in TTGO Tiny Basic introductory comments

## Testing
- `sed -n '10,15p' Arduino/TTGO_Tiny_Basic/TTGO_Tiny_Basic_1/TTGO_Tiny_Basic_1.ino`

------
https://chatgpt.com/codex/tasks/task_e_6840e51c849083248412ab3b15bbc772