### PR TITLE
Fix Raspberry Pi OS name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ My current focus is on the unusual OS and a game called "System Revival" which w
 3. **Windows XP                                   (Dell Vostro 200)**
 4. **System 7.1                                   (Macintosh Plus)**
 5. **MacOS 10.3                                   (iMac G3 (Tray-Loading, 333 MHz))**
-6. **Raspberrypi OS                               (Raspberry Pi 5)**
+6. **Raspberry Pi OS                              (Raspberry Pi 5)**
 7. **Tiny Basic 1.5                               (2X Arduino Nano)**
 8. **Tiny BASIC 2.1                               (TTGO VGA Mini32)**
 9. **NO OS                                        (Lenovo M72e)**


### PR DESCRIPTION
### Motivation

- Correct the product name from `Raspberrypi OS` to `Raspberry Pi OS` in the "My Computers" list.
- Preserve the original list formatting and alignment when making the change.
- Improve documentation accuracy and consistency across the repository.

### Description

- Modified `README.md` to replace `Raspberrypi OS` with `Raspberry Pi OS` in the My Computers section.
- The change is a single-line substitution resulting in one insertion and one deletion in the file.
- Only `README.md` was updated to keep the visible list alignment unchanged.
- The change was committed with the message `Fix Raspberry Pi OS name`.

### Testing

- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dc3e64ce483249746ac7b81b8a62c)