### PR TITLE
Guard WFE /run when filename missing

### DIFF
--- a/QTOS/CONTEXTS/wfe.py
+++ b/QTOS/CONTEXTS/wfe.py
@@ -35,7 +35,11 @@ def handle_wfe(wfe_path_ref):
                 print(f"{LIGHT_GREEN}[ DRIVE ] → Switched to {drive}:\\{RESET}")
             
             elif cmd.startswith('/run'):
-                exe = cmd.split(' ', 1)[1].strip()
+                parts = cmd.split(' ', 1)
+                if len(parts) < 2 or not parts[1].strip():
+                    print(f"{RED}[ ERR ] No filename provided{RESET}")
+                    continue
+                exe = parts[1].strip()
                 if wfe_path_ref[0]:
                     full_path = Path(wfe_path_ref[0]) / exe
                     if full_path.is_file():


### PR DESCRIPTION
### Motivation
- Prevent an error when `handle_wfe` processes a `/run` command without a filename by avoiding an out-of-range access to split parts.
- Provide a clear, styled error message and skip execution when the filename argument is missing.
- Preserve existing behavior for valid `/run` invocations and when no drive is selected.

### Description
- Updated `QTOS/CONTEXTS/wfe.py` in `handle_wfe` to split the `/run` command into `parts = cmd.split(' ', 1)` instead of indexing directly.
- Added a guard `if len(parts) < 2 or not parts[1].strip(): print(f"{RED}[ ERR ] No filename provided{RESET}"); continue` to print an error and skip processing when no filename is given.
- Left the existing drive check, `Path` resolution, `is_file()` check, and `subprocess.Popen` invocation unchanged so normal execution flow is preserved.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dc3f7b8148324b4e87c6d3590d3d2)