### PR TITLE
Update edit_handler docstring branding

### DIFF
--- a/QTOS/DEPENDENCIES/edit_handler.py
+++ b/QTOS/DEPENDENCIES/edit_handler.py
@@ -6,7 +6,7 @@ from helpers import YELLOW, LIGHT_GREEN, RESET, RED, GREEN
 
 def edit_file(filepath, urn_label):
     """
-    Optimized text-based editor for BOSCHOS:
+    Optimized text-based editor for QTOS:
       [ MOD ] → Editing "<FILENAME>" in <URN>
     Commands (one flag per command):
       /edit -i  <n>        – insert one line at position n (only append at end)


### PR DESCRIPTION
### Motivation
- Replace the outdated "BOSCHOS" branding with "QTOS" (Quantified Ternary OS) in the `edit_file` docstring to reflect the current project name.
- Leave the rest of the command documentation unchanged to preserve usage instructions.

### Description
- Modify the docstring in `QTOS/DEPENDENCIES/edit_handler.py` to change the header line from "Optimized text-based editor for BOSCHOS:" to "Optimized text-based editor for QTOS:".
- No other code paths, logic, or behavior were altered in the file.

### Testing
- No automated tests were run for this change.
- The file update was staged and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dc408c8c4832481ba93a15fa4e1a2)