### PR TITLE
Add REM doctest to BASIC lexer docstring

### DIFF
--- a/QTOS/BASIC/lexer.py
+++ b/QTOS/BASIC/lexer.py
@@ -32,6 +32,9 @@ Column: 12 Category: UNSIGNEDFLOAT Lexeme: 3.45
 >>> tokenlist = lexer.tokenize('100 LET I = "HELLO"')
 >>> tokenlist[4].pretty_print()
 Column: 12 Category: STRING Lexeme: HELLO
+>>> tokenlist = lexer.tokenize('100 REM hello world')
+>>> tokenlist[1].lexeme
+'REM hello world'
 """
 
 from basictoken import BASICToken as Token


### PR DESCRIPTION
### Motivation

- Ensure the lexer correctly captures the entire REM comment text as a single token lexeme.
- Follow existing doctest patterns already present in the `QTOS/BASIC/lexer.py` docstring for consistent coverage.
- Add a minimal regression check to prevent future changes from truncating REM comments.

### Description

- Add a doctest to `QTOS/BASIC/lexer.py` that tokenizes `100 REM hello world` and asserts `tokenlist[1].lexeme` equals `'REM hello world'`.
- Keep the doctest style consistent with existing examples that use `Lexer().tokenize(...)` and token attribute inspection.
- No functional changes to `Lexer.tokenize` or public API behavior were made.

### Testing

- Ran `python QTOS/BASIC/lexer.py` which executes `doctest.testmod()` to run module doctests.
- The doctest run completed successfully with the new REM test passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dc42100908324bb016093b18dd0dd)